### PR TITLE
Fix: Fix release configuration  

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -13,7 +13,7 @@ module.exports = {
     [
       '@semantic-release/git',
       {
-        assets: ['CHANGELOG.md'],
+        assets: ['CHANGELOG.md', 'dist/*'],
         message: 'chore(release): set `package.json` to ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },
     ],


### PR DESCRIPTION
BREAKING CHANGE: Fixed semantic release configuration by adding the `dist` folder.
Without this change, the `npm package` would not include the necessary code.