### PR TITLE
Fix: Fixes for calculating span and isEnd for events.

### DIFF
--- a/src/components/ResourceEvents.jsx
+++ b/src/components/ResourceEvents.jsx
@@ -277,7 +277,7 @@ class ResourceEvents extends Component {
         headerItem.events.forEach((evt, idx) => {
           if (idx < renderEventsMaxIndex && evt !== undefined && evt.render) {
             let durationStart = localeDayjs(new Date(startDate));
-            let durationEnd = localeDayjs(endDate).add(1, 'days');
+            let durationEnd = localeDayjs(endDate);
             if (cellUnit === CellUnit.Hour) {
               durationStart = localeDayjs(new Date(startDate)).add(config.dayStartFrom, 'hours');
               durationEnd = localeDayjs(endDate).add(config.dayStopTo + 1, 'hours');

--- a/src/components/SchedulerData.js
+++ b/src/components/SchedulerData.js
@@ -908,6 +908,9 @@ export default class SchedulerData {
       windowStart = new Date(this.startDate),
       windowEnd = new Date(this.endDate);
 
+    windowStart.setHours(0, 0, 0, 0);
+    windowEnd.setHours(23, 59, 59);
+
     if (this.viewType === ViewType.Day) {
       if (headers.length > 0) {
         const day = new Date(headers[0].time);
@@ -922,18 +925,11 @@ export default class SchedulerData {
           span = Math.ceil(timeBetween(eventStart, eventEnd, 'minutes') / this.config.minuteStep);
         }
       }
-    } else if (this.viewType === ViewType.Week) {
+    } else if (this.viewType === ViewType.Week || this.viewType === ViewType.Month || this.viewType === ViewType.Quarter || this.viewType === ViewType.Year) {
       const startDate = windowStart < eventStart ? eventStart : windowStart;
-      span = Math.ceil(timeBetween(startDate, eventEnd, 'days'));
-    } else if (this.viewType === ViewType.Month) {
-      const endDate = eventStart.getMonth() === eventEnd.getMonth() ? eventEnd : dayjs(eventStart).endOf('month').toDate();
-      span = Math.ceil(timeBetween(eventStart, endDate, 'days'));
-    } else if (this.viewType === ViewType.Quarter || this.viewType === ViewType.Year) {
-      span = Math.ceil(timeBetween(eventStart, eventEnd, 'days'));
+      const endDate = windowEnd > eventEnd ? eventEnd : windowEnd;
+      span = Math.ceil(timeBetween(startDate, endDate, 'days'));
     } else {
-      windowStart.setHours(0, 0, 0, 0);
-      windowEnd.setHours(23, 59, 59);
-
       if (this.cellUnit === CellUnit.Day) {
         eventEnd.setHours(23, 59, 59);
         eventStart.setHours(0, 0, 0, 0);


### PR DESCRIPTION
BREAKING CHANGE:

### Calculating event span in Scheduler.js

Event span was being calculated incorrectly for events that start earlier than the current view start date. The resulting effect was the event being displayed to have as many days in the later view as in the earlier. As an example, an event spanning from April 20th - May 5th being viewed in a monthly view would actually display from April 20th - May 10th.

### Calculating the "isEnd" flag in ResourceEvents.js

When calculating this property, the end of the event is compared to the end of the current view, but the view end date was having an extra day added to it. I couldn't figure out why, since doing so causes the "isEnd" flag to be true even for some cases where the event end is actually beyond the current view end, resulting in the event being rendered with a curved end when it should be flat. As an example, an event starting on April 20th and finishing on May 1st would render with a curved end on April 30th when in the April month view.

Thanks to @adam-m-clark