### PR TITLE
Fixed dist entrypoint to be bundle.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "README.md",
     "License"
   ],
-  "main": "dist/index.js",
+  "main": "dist/bundle.js",
   "homepage": "https://react-big-schedule.vercel.app",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Attempting to fix issue #215 by setting the main entrypoint to bundle.js .
Feel free to evaluate.